### PR TITLE
.NET GUI 'mono' compatibility to run under Linux

### DIFF
--- a/software/eeprog/MainForm.Designer.cs
+++ b/software/eeprog/MainForm.Designer.cs
@@ -83,6 +83,7 @@
       this.m_lstChipType.Name = "m_lstChipType";
       this.m_lstChipType.Size = new System.Drawing.Size(121, 21);
       this.m_lstChipType.TabIndex = 11;
+      this.m_lstChipType.SelectedIndexChanged += new System.EventHandler(this.OnChipTypeChanged);
       // 
       // label3
       // 
@@ -102,6 +103,7 @@
       this.m_lstAddressSize.Name = "m_lstAddressSize";
       this.m_lstAddressSize.Size = new System.Drawing.Size(121, 21);
       this.m_lstAddressSize.TabIndex = 9;
+      this.m_lstAddressSize.SelectedIndexChanged += new System.EventHandler(this.OnAddressSizeChanged);
       // 
       // label6
       // 
@@ -121,6 +123,7 @@
       this.m_lstCapacity.Name = "m_lstCapacity";
       this.m_lstCapacity.Size = new System.Drawing.Size(121, 21);
       this.m_lstCapacity.TabIndex = 7;
+      this.m_lstCapacity.SelectedIndexChanged += new System.EventHandler(this.OnCapacityChanged);
       // 
       // label5
       // 
@@ -140,6 +143,7 @@
       this.m_lstPageSize.Name = "m_lstPageSize";
       this.m_lstPageSize.Size = new System.Drawing.Size(121, 21);
       this.m_lstPageSize.TabIndex = 5;
+      this.m_lstPageSize.SelectedIndexChanged += new System.EventHandler(this.OnPageSizeChanged);
       // 
       // label4
       // 

--- a/software/eeprog/eeprog.csproj
+++ b/software/eeprog/eeprog.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,7 +38,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
Thanks for this nice project!
.NET GUI executable may be ran both under Windows and Linux.
Just few modification required.
Use on Linux:
`mono eeprog.exe`

This PR contains the following:
1. Amended for the mono version of the .NET platform, to run executable both on Linux an on Windows
2. Added support for .e2p input EEPROM image files.
3. Added some EPPROM models.
